### PR TITLE
Remove dub settings.json

### DIFF
--- a/ldc2-packaging/3-package-ldc.sh
+++ b/ldc2-packaging/3-package-ldc.sh
@@ -11,9 +11,6 @@ fi
 
 cp $SRC_DIR/ldc/LICENSE $PKG_DIR
 
-# Add Dub settings file to package
-cp -r pkgfiles/dub $PKG_DIR/etc
-
 # Rename pkg/ to the final name and zip it up.
 cd $BUILD_ROOT
 rm -rf $PKG_BASE

--- a/ldc2-packaging/pkgfiles/dub/settings.json
+++ b/ldc2-packaging/pkgfiles/dub/settings.json
@@ -1,3 +1,0 @@
-{
-    "defaultCompiler" : "ldc2"
-}


### PR DESCRIPTION
Ever since dub 1.7, which shipped with my patch to first try using the D compiler next to dub, dlang/dub@2ad4038, this file isn't needed anymore.

Btw, still using these scripts? I see they haven't been updated in awhile.